### PR TITLE
RBEDIT_ARCH -> TARGET_OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Quick Start
 ./scripts/build.sh
 
 # Compile for darwin arch:
-RBEDIT_ARCH=darwin ./scripts/build.sh
+TARGET_OS=darwin ./scripts/build.sh
 
 # Compile for linux arch:
-RBEDIT_ARCH=linux ./scripts/build.sh
+TARGET_OS=linux ./scripts/build.sh
 ```
 
 The only build requirement is Docker and the binary has no runtime dependencies.


### PR DESCRIPTION
Looking at: https://github.com/rakshasa/rbedit/blob/master/scripts/build.sh#L10 (`./scripts/build.sh` Line 10)

```bash
TARGET_OS="${TARGET_OS:-}"
```

However, there isn't any traces of this variable being used:

```shell
$ grep -R RBEDIT_ARCH .
./README.md:RBEDIT_ARCH=darwin ./scripts/build.sh
./README.md:RBEDIT_ARCH=linux ./scripts/build.sh
$ 
$ grep -R TARGET_OS . | wc -l
21
$
```

- - - 

Looking at the build script more in depth for variables:

```shell
$ cat scripts/build.sh
[...]
BUILD_IMAGE="${BUILD_IMAGE:-build-env}"
BUILD_MARKDOWN="${BUILD_MARKDOWN:-no}"
BUILD_DOCS="${BUILD_DOCS:-no}"
BUILD_DIR="${BUILD_DIR:-./build}"

TARGET_OS="${TARGET_OS:-}"
TARGET_ARCH="${TARGET_ARCH:-amd64}"

case "${TARGET_OS:-}" in
  darwin|linux|windows)
    echo "TARGET_OS=${TARGET_OS}"
[...]
```

- `TARGET_OS` you can see being used for macOS, Linux & Windows (rather than `RBEDIT_ARCH`)
- `TARGET_ARCH` you can see `amd64` being set. 

So it looks like the prefix (`RBEDIT_`) and suffix  (`_ARCH`) are both incorrect.