### PR TITLE
Update hash.go

### DIFF
--- a/cmd/common/hash.go
+++ b/cmd/common/hash.go
@@ -47,7 +47,7 @@ func newHashInfoCommand() *cobra.Command {
 
 			batch := actions.NewBatch()
 			// TODO: Allow both Bytes and Hash alone.
-			batch.Append(actions.NewTemplateExecute("{{ .Input.TorrentInfo.Hash.Bytes }}"))
+			batch.Append(actions.NewTemplateExecute("{{ .Input.Torrent.Hash.Bytes }}"))
 
 			if err := input.Execute(metadata, batch.CreateFunction(output)); err != nil {
 				printCommandErrorAndExit(cmd, err)


### PR DESCRIPTION
`.Input` has no member named `TorrentInfo`. `TorrentInfo` is the type of it but the member itself is named `Torrent`